### PR TITLE
Brandontran1220/add missing color

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 @import "tailwindcss";
 
 @theme {
-  --color-pse-purple-100: #F9F4FF;
+  --color-pse-purple-100: #f9f4ff;
   --color-pse-purple-200: #b09fca;
   --color-pse-purple-300: #7a63a3;
   --color-pse-purple-400: #544175;


### PR DESCRIPTION
- Add #F9F4FF color
- It wasn't listed in the palette 

For these:
<img width="398" height="206" alt="image" src="https://github.com/user-attachments/assets/a386385e-03cc-4647-b591-1c8878234d72" />

<img width="428" height="319" alt="image" src="https://github.com/user-attachments/assets/1b32c23f-5889-4c99-959e-5478eb6bbe61" />
